### PR TITLE
Add Streaming Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ A unified Swift package for connecting to various Large Language Model (LLM) bac
 ## Supported Providers
 
 ### OpenRouter
+
 - **Purpose**: Access to multiple LLM models through a single API
 - **Features**: Model listing, API key validation, chat completions
 - **Authentication**: API key required
 
 ### KoboldCPP
+
 - **Purpose**: Local LLM inference server
 - **Features**: Direct HTTP connection to local instances
 - **Authentication**: No API key required (local connection)
@@ -71,15 +73,15 @@ case .failure(let error):
     print("Connection failed: \(error)")
 }
 
-// Send a message
-let requestBuilder = RequestBodyBuilder(
-    selectedModel: "openai/gpt-4",
+// Send a message (builder-based API)
+let requestBuilder = OpenRouterRequestBuilder(
+    model: "openai/gpt-4",
     messages: [
         RequestBodyMessages(role: .user, message: "Hello, how are you?")
     ]
 )
 
-let response = await apiManager.sendMessage(promptModel: requestBuilder)
+let response = await apiManager.sendMessage(builder: requestBuilder)
 switch response {
 case .success(let modelResponse):
     print("Response: \(modelResponse.text ?? "No response")")
@@ -87,6 +89,52 @@ case .failure(let error):
     print("Error: \(error)")
 }
 ```
+
+### Streaming with OpenRouter
+
+```swift
+import SwiftLLMSDK
+import SwiftUI
+
+let openRouterAPI = OpenRouterAPI(
+    selectedModel: "openai/gpt-4o-mini",
+    apiKey: "your-api-key-here"
+)
+let apiManager = APIManager(forService: openRouterAPI)
+
+let builder = OpenRouterRequestBuilder(
+    model: "openai/gpt-4o-mini",
+    messages: [
+        RequestBodyMessages(role: .user, message: "Stream this response?")
+    ],
+    stream: true
+)
+
+// SwiftUI example
+struct ChatView: View {
+    @State private var assistantText = ""
+
+    var body: some View {
+        ScrollView {
+            Text(assistantText)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+        }
+        .task {
+            for await result in apiManager.streamMessage(builder: builder) {
+                switch result {
+                case .success(let model):
+                    await MainActor.run { assistantText = model.text ?? "" }
+                case .failure(let error):
+                    print("stream error: \(error)")
+                }
+            }
+        }
+    }
+}
+```
+
+NOTE: Streaming with koboldCPP uses the same manager method, simply pass the correct request builder.
 
 ### Basic KoboldCPP Usage
 
@@ -111,14 +159,14 @@ case .failure(let error):
     print("Connection failed: \(error)")
 }
 
-// Send a prompt
-let requestBuilder = RequestBodyBuilder(
+// Send a prompt (builder-based API)
+let requestBuilder = KoboldRequestBuilder(
     prompt: "Once upon a time",
     maxLength: 100,
     temperature: 0.8
 )
 
-let response = await apiManager.sendMessage(promptModel: requestBuilder)
+let response = await apiManager.sendMessage(builder: requestBuilder)
 switch response {
 case .success(let modelResponse):
     print("Generated text: \(modelResponse.text ?? "No response")")
@@ -152,17 +200,18 @@ if let koboldAPIResponse: KoboldAPIResponse = modelResponse.getRawResponse() {
 import SwiftLLMSDK
 
 // Set up character information
-let requestBuilder = RequestBodyBuilder(
-    selectedModel: "openai/gpt-4",
+let requestBuilder = OpenRouterRequestBuilder(
+    model: "openai/gpt-4",
     messages: [
         RequestBodyMessages(role: .user, message: "Hello there!")
     ],
+    systemPromptTemplate: nil,
     characterDescription: "A friendly AI assistant who loves to help with coding questions.",
     characterPersonality: "Enthusiastic, patient, and knowledgeable about programming.",
     characterScenario: "You are helping a developer learn Swift programming."
 )
 
-let response = await apiManager.sendMessage(promptModel: requestBuilder)
+let response = await apiManager.sendMessage(builder: requestBuilder)
 ```
 
 ### Using Character Cards with KoboldCPP
@@ -171,7 +220,7 @@ let response = await apiManager.sendMessage(promptModel: requestBuilder)
 import SwiftLLMSDK
 
 // For KoboldCPP, character info goes into memory and prompt
-let requestBuilder = RequestBodyBuilder(
+let requestBuilder = KoboldRequestBuilder(
     prompt: "User: Hello there!\nAssistant:",
     memory: "You are a friendly AI assistant who loves to help with coding questions. You are enthusiastic, patient, and knowledgeable about programming.",
     maxLength: 150,
@@ -179,7 +228,7 @@ let requestBuilder = RequestBodyBuilder(
     stopSequence: ["\nUser:", "\nAssistant:"]
 )
 
-let response = await apiManager.sendMessage(promptModel: requestBuilder)
+let response = await apiManager.sendMessage(builder: requestBuilder)
 ```
 
 ## ChubAI Character Import
@@ -242,27 +291,26 @@ case .failure(let error):
 ### Advanced Parameter Configuration
 
 ```swift
-let requestBuilder = RequestBodyBuilder(
-    selectedModel: "anthropic/claude-3-haiku",
+let requestBuilder = OpenRouterRequestBuilder(
+    model: "anthropic/claude-3-haiku",
     messages: [
         RequestBodyMessages(role: .system, message: "You are a helpful assistant."),
         RequestBodyMessages(role: .user, message: "Explain quantum computing")
     ],
-    maxContextLength: 8192,
-    maxLength: 500,
+    maxTokens: 500,
     temperature: 0.7,
     topP: 0.9,
     topK: 40,
-    stopSequence: ["\n\nHuman:", "\n\nAssistant:"],
-    frequencyPen: 0.1,
-    presencePen: 0.1
+    stop: ["\n\nHuman:", "\n\nAssistant:"],
+    frequencyPenalty: 0.1,
+    presencePenalty: 0.1
 )
 ```
 
 ### Error Handling
 
 ```swift
-let response = await apiManager.sendMessage(promptModel: requestBuilder)
+let response = await apiManager.sendMessage(builder: requestBuilder)
 switch response {
 case .success(let modelResponse):
     print("Success!")
@@ -295,33 +343,39 @@ case .failure(let error):
 ### Core Classes
 
 #### `APIManager<T: LanguageModelService>`
+
 Generic manager for handling API calls to different LLM services.
 
 **Methods:**
-- `sendMessage(promptModel: RequestBodyBuilder) async -> Result<ModelResponse, APIError>`
+
+- `sendMessage(builder: OpenRouterRequestBuilder) async -> Result<ModelResponse, APIError>`
+- `sendMessage(builder: KoboldRequestBuilder) async -> Result<ModelResponse, APIError>`
+- `streamMessage(builder: OpenRouterRequestBuilder) -> AsyncStream<Result<ModelResponse, APIError>>`
+- `streamMessage(builder: KoboldRequestBuilder) -> AsyncStream<Result<ModelResponse, APIError>>`
 - `connect() async -> Result<String, APIError>` (OpenRouter/Kobold specific)
 - `getAvailableModels() async -> Result<[OpenRouterModel], APIError>` (OpenRouter only)
 
-#### `RequestBodyBuilder`
-Builder class for constructing requests with support for both OpenRouter and KoboldCPP parameters.
+#### Request Builders
 
-**Key Properties:**
-- `selectedModel: String` - Model identifier (OpenRouter)
-- `messages: [RequestBodyMessages]` - Chat messages (OpenRouter)
-- `prompt: String?` - Direct prompt text (KoboldCPP)
-- `memory: String?` - System/character context (KoboldCPP)
-- `temperature: Double?` - Sampling temperature
-- `maxLength: Int?` - Maximum response length
-- Character card properties: `characterDescription`, `characterPersonality`, `characterScenario`
+- `OpenRouterRequestBuilder`: Build chat-completion requests for OpenRouter.
+  - Fields include `model`, `messages`, `stop`, `temperature`, `topP`, `minP`, `topA`, `topK`, `maxTokens`, `repetitionPenalty`, `frequencyPenalty`, `presencePenalty`, `stream`, and optional system/character fields.
+- `KoboldRequestBuilder`: Build text-generation requests for KoboldCPP.
+  - Fields include `prompt`, `memory`, `maxContextLength`, `maxLength`, `temperature`, `tfs`, `topA`, `topK`, `topP`, `minP`, `typical`, `repetitionPenalty`, `repetitionRange`, `repetitionSlope`, `stopSequence`, `trimStop`, `samplerOrder`, `promptTemplate`.
+
+Compatibility: The legacy `RequestBodyBuilder` remains available but new code should prefer provider-specific builders.
 
 #### `ModelResponse`
+
 Unified response structure containing:
+
 - `text: String?` - Generated text response
 - `role: String?` - Response role (usually "assistant")
 - `responseTokens: Int?` - Tokens used in response
 - `promptTokens: Int?` - Tokens used in prompt
+- `streaming`: Bool? - If the response is currently streaming data
 - `rawResponse: Codable` - Original API response
 
+Note: Streaming uses `AsyncStream<Result<ModelResponse, APIError>>`. Each emission contains the accumulated `text` so far; the last emission is the final content.
 
 ## Contributing
 

--- a/Sources/SwiftLLMSDK/APIManager.swift
+++ b/Sources/SwiftLLMSDK/APIManager.swift
@@ -64,6 +64,16 @@ extension APIManager where T: KoboldAPIBase {
         return await api.getModel()
     }
 
+    public func streamMessage(builder: KoboldRequestBuilder) -> AsyncStream<Result<ModelResponse, APIError>> {
+        guard let api = api as? KoboldAPI else {
+            return AsyncStream { continuation in
+                continuation.yield(.failure(.invalidService))
+                continuation.finish()
+            }
+        }
+        return api.streamMessage(builder: builder)
+    }
+
     public func sendMessage(builder: KoboldRequestBuilder) async -> Result<ModelResponse, APIError> {
         guard let api = api as? KoboldAPI else {
             return .failure(.invalidService)
@@ -84,6 +94,7 @@ public struct ModelResponse: ResponseModel, @unchecked Sendable {
     public var text: String?
     public var responseTokens: Int?
     public var promptTokens: Int?
+    public var streaming: Bool?
     public var rawResponse: Codable
     
     public init<T: Codable>(
@@ -91,12 +102,14 @@ public struct ModelResponse: ResponseModel, @unchecked Sendable {
         text: String? = nil,
         responseTokens: Int? = nil,
         promptTokens: Int? = nil,
+        streaming: Bool? = false,
         rawResponse: T
     ) {
         self.role = role
         self.text = text
         self.responseTokens = responseTokens
         self.promptTokens = promptTokens
+        self.streaming = streaming
         self.rawResponse = rawResponse
     }
     

--- a/Sources/SwiftLLMSDK/APIManager.swift
+++ b/Sources/SwiftLLMSDK/APIManager.swift
@@ -16,17 +16,6 @@ public class APIManager<T: LanguageModelService> {
     public init(forService api: T) {
         self.api = api
     }
-
-    public func sendMessage(promptModel: RequestBodyBuilder) async -> Result<ModelResponse, APIError> {
-        let result = await api.sendMessage(promptModel: promptModel)
-
-        switch result {
-        case .success(let response):
-            return .success(response)
-        case .failure(let error):
-            return .failure(error)
-        }
-    }
 }
 
 // MARK: - OpenRouter Functions
@@ -37,6 +26,23 @@ extension APIManager where T: OpenRouterBase {
         }
 
         return await api.checkAPIKey()
+    }
+
+    public func sendMessage(builder: OpenRouterRequestBuilder) async -> Result<ModelResponse, APIError> {
+        guard let api = api as? OpenRouterAPI else {
+            return .failure(.invalidService)
+        }
+        return await api.sendMessage(builder: builder)
+    }
+
+    public func streamMessage(builder: OpenRouterRequestBuilder) -> AsyncStream<Result<ModelResponse, APIError>> {
+        guard let api = api as? OpenRouterAPI else {
+            return AsyncStream { continuation in
+                continuation.yield(.failure(.invalidService))
+                continuation.finish()
+            }
+        }
+        return api.streamMessage(builder: builder)
     }
 
     public func getAvailableModels() async -> Result<[OpenRouterModel], APIError> {
@@ -57,6 +63,13 @@ extension APIManager where T: KoboldAPIBase {
 
         return await api.getModel()
     }
+
+    public func sendMessage(builder: KoboldRequestBuilder) async -> Result<ModelResponse, APIError> {
+        guard let api = api as? KoboldAPI else {
+            return .failure(.invalidService)
+        }
+        return await api.sendMessage(builder: builder)
+    }
 }
 
 public protocol ResponseModel {
@@ -66,7 +79,7 @@ public protocol ResponseModel {
     var promptTokens: Int? { get }
 }
 
-public struct ModelResponse: ResponseModel {
+public struct ModelResponse: ResponseModel, @unchecked Sendable {
     public var role: String?
     public var text: String?
     public var responseTokens: Int?

--- a/Sources/SwiftLLMSDK/KoboldCPP/KoboldAPI.swift
+++ b/Sources/SwiftLLMSDK/KoboldCPP/KoboldAPI.swift
@@ -36,6 +36,17 @@ public struct KoboldAPI: LanguageModelService, KoboldAPIBase {
         await getString(endpoint: "/api/v1/model")
     }
 
+    public func streamMessage(builder: KoboldRequestBuilder) -> AsyncStream<Result<ModelResponse, APIError>> {
+        let requestModel = builder.build()
+
+        return sendStreamedRequest(
+            forAPI: KoboldAPI.self,
+            path: "/api/extra/generate/stream",
+            method: "POST",
+            requestBody: requestModel.toJSON().data(using: .utf8)
+        )
+    }
+
     public func sendMessage(promptModel: RequestBodyBuilder) async -> Result<ModelResponse, APIError> {
         let koboldRequest = promptModel.buildKoboldBody()
         let koboldRequestData = koboldRequest.toJSON().data(using: .utf8)

--- a/Sources/SwiftLLMSDK/KoboldCPP/KoboldAPI.swift
+++ b/Sources/SwiftLLMSDK/KoboldCPP/KoboldAPI.swift
@@ -49,4 +49,24 @@ public struct KoboldAPI: LanguageModelService, KoboldAPIBase {
             return .failure(error)
         }
     }
+
+    // Overload: send using provider-specific builder
+    public func sendMessage(builder: KoboldRequestBuilder) async -> Result<ModelResponse, APIError> {
+        let koboldRequest = builder.build()
+        let koboldRequestData = koboldRequest.toJSON().data(using: .utf8)
+
+        let result = await sendRequest(
+            for: KoboldAPIResponse.self,
+            path: "/api/v1/generate",
+            method: "POST",
+            requestBody: koboldRequestData
+        )
+
+        switch result {
+        case .success(let response):
+            return .success(response.toModelResponse())
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
 }

--- a/Sources/SwiftLLMSDK/KoboldCPP/KoboldResponse.swift
+++ b/Sources/SwiftLLMSDK/KoboldCPP/KoboldResponse.swift
@@ -74,3 +74,14 @@ extension KoboldAPIResponse {
 }
 
 
+public class KoboldStreamChunk: Codable, @unchecked Sendable {
+    public var token: String? 
+    public var finishReason: String?
+
+    enum CodingKeys: String, CodingKey {
+        case token = "token"
+        case finishReason = "finish_reason"
+    }
+}
+
+

--- a/Sources/SwiftLLMSDK/OpenRouter/OpenRouterAPI.swift
+++ b/Sources/SwiftLLMSDK/OpenRouter/OpenRouterAPI.swift
@@ -42,6 +42,110 @@ public struct OpenRouterAPI: LanguageModelService, OpenRouterBase {
         }
     }
 
+    // Overload: send using provider-specific builder
+    public func sendMessage(builder: OpenRouterRequestBuilder) async -> Result<ModelResponse, APIError> {
+        let openRouterRequest = builder.build()
+        let openRouterRequestData = openRouterRequest.toJSON().data(using: .utf8)
+
+        let result = await sendRequest(
+            for: OpenRouterAPIResponse.self,
+            path: "/chat/completions",
+            method: "POST",
+            requestBody: openRouterRequestData
+        )
+
+        switch result {
+        case .success(let response):
+            return .success(response.toModelResponse())
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    // MARK: - Streaming
+    // Returns an AsyncStream emitting partial ModelResponse updates and a final value.
+    public func streamMessage(builder: OpenRouterRequestBuilder) -> AsyncStream<Result<ModelResponse, APIError>> {
+        var requestBuilder = builder
+        requestBuilder.stream = true
+        let requestModel = requestBuilder.build()
+
+        let urlString = baseURL + "/chat/completions"
+        let timeout = timeoutInterval
+        let authKey = apiKey
+        let session = urlSession
+
+        let (stream, continuation) = AsyncStream<Result<ModelResponse, APIError>>.makeStream()
+
+        guard let url = URL(string: urlString) else {
+            continuation.yield(.failure(.invalidURL))
+            continuation.finish()
+            return stream
+        }
+
+        var request = URLRequest(url: url, timeoutInterval: timeout)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("JAX AI", forHTTPHeaderField: "X-Title")
+        request.setValue("https://jax-ai-com.l.ink/", forHTTPHeaderField: "HTTP-Referer")
+        if let authKey {
+            request.setValue("Bearer \(authKey)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = requestModel.toJSON().data(using: .utf8)
+
+        Task.detached(priority: .medium) {
+            do {
+                let (bytes, response) = try await session.bytes(for: request)
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    continuation.yield(.failure(.invalidResponse))
+                    continuation.finish()
+                    return
+                }
+                guard (200...299).contains(httpResponse.statusCode) else {
+                    continuation.yield(.failure(.serverError(code: httpResponse.statusCode)))
+                    continuation.finish()
+                    return
+                }
+
+                var accumulatedText = ""
+                for try await line in bytes.lines {
+                    // SSE lines typically start with "data: "
+                    guard line.hasPrefix("data:") else { continue }
+                    let payload = line.dropFirst(5).trimmingCharacters(in: .whitespaces)
+                    if payload == "[DONE]" {
+                        let final = ModelResponse(role: "assistant", text: accumulatedText, responseTokens: nil, promptTokens: nil, rawResponse: OpenRouterAPIResponse())
+                        continuation.yield(.success(final))
+                        continuation.finish()
+                        break
+                    }
+
+                    if let jsonData = payload.data(using: .utf8) {
+                        do {
+                            let decoder = JSONDecoder()
+                            let chunk = try decoder.decode(OpenRouterStreamChunk.self, from: jsonData)
+                            let deltaText = chunk.choices?.first?.delta?.content ?? ""
+                            if !deltaText.isEmpty {
+                                accumulatedText += deltaText
+                                let partial = ModelResponse(role: chunk.choices?.first?.delta?.role ?? "assistant", text: accumulatedText, responseTokens: nil, promptTokens: nil, rawResponse: chunk)
+                                continuation.yield(.success(partial))
+                            }
+                        } catch {
+                            // Ignore non-JSON keepalives or unknown fragments
+                            continue
+                        }
+                    }
+                }
+            } catch let error as URLError where error.code == .timedOut {
+                continuation.yield(.failure(.timeout))
+                continuation.finish()
+            } catch {
+                continuation.yield(.failure(.invalidData))
+                continuation.finish()
+            }
+        }
+
+        return stream
+    }
+
     // TODO: Update this to return the actual Key info. May be useful for monitoring usage ect. 
     public func checkAPIKey() async -> Result<String, APIError> {
         let result = await sendRequest(for: OpenRouterAPIKeyResponse.self, path: "/key", method: "GET")

--- a/Sources/SwiftLLMSDK/OpenRouter/OpenRouterAPI.swift
+++ b/Sources/SwiftLLMSDK/OpenRouter/OpenRouterAPI.swift
@@ -6,7 +6,6 @@ public protocol OpenRouterBase {
 }
 
 public struct OpenRouterAPI: LanguageModelService, OpenRouterBase {
-    // public typealias ResponseType = OpenRouterResponse
 
     public var urlSession: URLSession
     public var baseURL: String
@@ -69,81 +68,12 @@ public struct OpenRouterAPI: LanguageModelService, OpenRouterBase {
         requestBuilder.stream = true
         let requestModel = requestBuilder.build()
 
-        let urlString = baseURL + "/chat/completions"
-        let timeout = timeoutInterval
-        let authKey = apiKey
-        let session = urlSession
-
-        let (stream, continuation) = AsyncStream<Result<ModelResponse, APIError>>.makeStream()
-
-        guard let url = URL(string: urlString) else {
-            continuation.yield(.failure(.invalidURL))
-            continuation.finish()
-            return stream
-        }
-
-        var request = URLRequest(url: url, timeoutInterval: timeout)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("JAX AI", forHTTPHeaderField: "X-Title")
-        request.setValue("https://jax-ai-com.l.ink/", forHTTPHeaderField: "HTTP-Referer")
-        if let authKey {
-            request.setValue("Bearer \(authKey)", forHTTPHeaderField: "Authorization")
-        }
-        request.httpBody = requestModel.toJSON().data(using: .utf8)
-
-        Task.detached(priority: .medium) {
-            do {
-                let (bytes, response) = try await session.bytes(for: request)
-                guard let httpResponse = response as? HTTPURLResponse else {
-                    continuation.yield(.failure(.invalidResponse))
-                    continuation.finish()
-                    return
-                }
-                guard (200...299).contains(httpResponse.statusCode) else {
-                    continuation.yield(.failure(.serverError(code: httpResponse.statusCode)))
-                    continuation.finish()
-                    return
-                }
-
-                var accumulatedText = ""
-                for try await line in bytes.lines {
-                    // SSE lines typically start with "data: "
-                    guard line.hasPrefix("data:") else { continue }
-                    let payload = line.dropFirst(5).trimmingCharacters(in: .whitespaces)
-                    if payload == "[DONE]" {
-                        let final = ModelResponse(role: "assistant", text: accumulatedText, responseTokens: nil, promptTokens: nil, rawResponse: OpenRouterAPIResponse())
-                        continuation.yield(.success(final))
-                        continuation.finish()
-                        break
-                    }
-
-                    if let jsonData = payload.data(using: .utf8) {
-                        do {
-                            let decoder = JSONDecoder()
-                            let chunk = try decoder.decode(OpenRouterStreamChunk.self, from: jsonData)
-                            let deltaText = chunk.choices?.first?.delta?.content ?? ""
-                            if !deltaText.isEmpty {
-                                accumulatedText += deltaText
-                                let partial = ModelResponse(role: chunk.choices?.first?.delta?.role ?? "assistant", text: accumulatedText, responseTokens: nil, promptTokens: nil, rawResponse: chunk)
-                                continuation.yield(.success(partial))
-                            }
-                        } catch {
-                            // Ignore non-JSON keepalives or unknown fragments
-                            continue
-                        }
-                    }
-                }
-            } catch let error as URLError where error.code == .timedOut {
-                continuation.yield(.failure(.timeout))
-                continuation.finish()
-            } catch {
-                continuation.yield(.failure(.invalidData))
-                continuation.finish()
-            }
-        }
-
-        return stream
+        return sendStreamedRequest(
+            forAPI: OpenRouterAPI.self,
+            path: "/chat/completions",
+            method: "POST",
+            requestBody: requestModel.toJSON().data(using: .utf8)
+        )
     }
 
     // TODO: Update this to return the actual Key info. May be useful for monitoring usage ect. 

--- a/Sources/SwiftLLMSDK/OpenRouter/OpenRouterResponse.swift
+++ b/Sources/SwiftLLMSDK/OpenRouter/OpenRouterResponse.swift
@@ -85,6 +85,38 @@ extension OpenRouterAPIResponse {
     }
 }
 
+// MARK: - Streaming (SSE) Chunk Models
+public class OpenRouterStreamChunk: Codable, @unchecked Sendable {
+    public var id: String?
+    public var provider: String?
+    public var model: String?
+    public var object: String?
+    public var created: Int?
+    public var choices: [OpenRouterStreamChoice]?
+    public var usage: OpenRouterUsage?
+}
+
+public class OpenRouterStreamChoice: Codable, @unchecked Sendable {
+    public var index: Int?
+    public var delta: OpenRouterStreamDelta?
+    public var finishReason: String?
+    public var nativeFinishReason: String?
+}
+
+public class OpenRouterStreamDelta: Codable, @unchecked Sendable {
+    public var role: String?
+    public var content: String?
+    public var reasoning: String?
+    public var reasoningDetails: [OpenRouterReasoningDetail]?
+}
+
+public class OpenRouterReasoningDetail: Codable, @unchecked Sendable {
+    public var type: String?
+    public var text: String?
+    public var format: String?
+    public var index: Int?
+}
+
 // MARK: - OpenRouter API Key Response
 public class OpenRouterAPIKeyResponse: Codable {
     var data: OpenRouterAPIKeyData?

--- a/Sources/SwiftLLMSDK/OpenRouter/stream_response_example.txt
+++ b/Sources/SwiftLLMSDK/OpenRouter/stream_response_example.txt
@@ -1,0 +1,101 @@
+: OPENROUTER PROCESSING
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":null,"reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"","reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"","reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"","reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"We","reasoning_details":[{"type":"reasoning.text","text":"We","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" need","reasoning_details":[{"type":"reasoning.text","text":" need","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" to","reasoning_details":[{"type":"reasoning.text","text":" to","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" respond","reasoning_details":[{"type":"reasoning.text","text":" respond","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":".","reasoning_details":[{"type":"reasoning.text","text":".","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" It's","reasoning_details":[{"type":"reasoning.text","text":" It's","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" a","reasoning_details":[{"type":"reasoning.text","text":" a","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" test","reasoning_details":[{"type":"reasoning.text","text":" test","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" message","reasoning_details":[{"type":"reasoning.text","text":" message","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":",","reasoning_details":[{"type":"reasoning.text","text":",","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" user","reasoning_details":[{"type":"reasoning.text","text":" user","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" says","reasoning_details":[{"type":"reasoning.text","text":" says","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" \"","reasoning_details":[{"type":"reasoning.text","text":" \"","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"Hello","reasoning_details":[{"type":"reasoning.text","text":"Hello","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"!","reasoning_details":[{"type":"reasoning.text","text":"!","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" This","reasoning_details":[{"type":"reasoning.text","text":" This","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" is","reasoning_details":[{"type":"reasoning.text","text":" is","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" a","reasoning_details":[{"type":"reasoning.text","text":" a","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" test","reasoning_details":[{"type":"reasoning.text","text":" test","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" message","reasoning_details":[{"type":"reasoning.text","text":" message","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":".\"","reasoning_details":[{"type":"reasoning.text","text":".\"","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" We","reasoning_details":[{"type":"reasoning.text","text":" We","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" should","reasoning_details":[{"type":"reasoning.text","text":" should","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" reply","reasoning_details":[{"type":"reasoning.text","text":" reply","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":" politely","reasoning_details":[{"type":"reasoning.text","text":" politely","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":".","reasoning_details":[{"type":"reasoning.text","text":".","format":"unknown","index":0}]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"","reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"","reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"","reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"","reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"","reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":null,"reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"Hello","reasoning":null,"reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"!","reasoning":null,"reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":null,"reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":" 👋","reasoning":null,"reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":" How","reasoning":null,"reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":" can","reasoning":null,"reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":" I","reasoning":null,"reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":" help","reasoning":null,"reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":" you","reasoning":null,"reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":" today","reasoning":null,"reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"?","reasoning":null,"reasoning_details":[]},"finish_reason":null,"native_finish_reason":null,"logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning":"","reasoning_details":[]},"finish_reason":"stop","native_finish_reason":"stop","logprobs":null}]}
+
+data: {"id":"gen-1754683934-e6O47uHizFxzKD4qQemE","provider":"AtlasCloud","model":"openai/gpt-oss-20b:free","object":"chat.completion.chunk","created":1754683935,"choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null,"native_finish_reason":null,"logprobs":null}],"usage":{"prompt_tokens":79,"completion_tokens":47,"total_tokens":126}}
+
+data: [DONE]

--- a/Sources/SwiftLLMSDK/RequestBuilders.swift
+++ b/Sources/SwiftLLMSDK/RequestBuilders.swift
@@ -1,0 +1,200 @@
+import Foundation
+
+/// Protocol for provider-specific request builders that can produce an Encodable request model.
+public protocol EncodableRequestBuilder {
+    associatedtype RequestModel: Encodable
+    func build() -> RequestModel
+}
+
+// MARK: - OpenRouter
+public struct OpenRouterRequestBuilder: EncodableRequestBuilder {
+    public typealias RequestModel = OpenRouterPromptModel
+
+    // Required
+    public var model: String
+    public var messages: [RequestBodyMessages]
+
+    // Optional tuning
+    public var stop: [String]?
+    public var temperature: Double?
+    public var topP: Double?
+    public var minP: Double?
+    public var topA: Double?
+    public var topK: Double?
+    public var maxTokens: Int?
+    public var repetitionPenalty: Double?
+    public var frequencyPenalty: Double?
+    public var presencePenalty: Double?
+    public var stream: Bool? = nil
+
+    // System context
+    public var systemPromptTemplate: String?
+    public var characterDescription: String?
+    public var characterPersonality: String?
+    public var characterScenario: String?
+
+    public init(
+        model: String,
+        messages: [RequestBodyMessages] = [],
+        stop: [String]? = nil,
+        temperature: Double? = nil,
+        topP: Double? = nil,
+        minP: Double? = nil,
+        topA: Double? = nil,
+        topK: Double? = nil,
+        maxTokens: Int? = nil,
+        repetitionPenalty: Double? = nil,
+        frequencyPenalty: Double? = nil,
+        presencePenalty: Double? = nil,
+        stream: Bool? = nil,
+        systemPromptTemplate: String? = nil,
+        characterDescription: String? = nil,
+        characterPersonality: String? = nil,
+        characterScenario: String? = nil
+    ) {
+        self.model = model
+        self.messages = messages
+        self.stop = stop
+        self.temperature = temperature
+        self.topP = topP
+        self.minP = minP
+        self.topA = topA
+        self.topK = topK
+        self.maxTokens = maxTokens
+        self.repetitionPenalty = repetitionPenalty
+        self.frequencyPenalty = frequencyPenalty
+        self.presencePenalty = presencePenalty
+        self.stream = stream
+        self.systemPromptTemplate = systemPromptTemplate
+        self.characterDescription = characterDescription
+        self.characterPersonality = characterPersonality
+        self.characterScenario = characterScenario
+    }
+
+    public func build() -> OpenRouterPromptModel {
+        var systemMessages: [OpenRouterMessage] = []
+        if let systemPromptTemplate {
+            systemMessages.append(OpenRouterMessage(role: "system", content: systemPromptTemplate))
+        }
+        if let characterDescription {
+            systemMessages.append(OpenRouterMessage(role: "system", content: characterDescription))
+        }
+        if let characterPersonality {
+            systemMessages.append(OpenRouterMessage(role: "system", content: characterPersonality))
+        }
+        if let characterScenario {
+            systemMessages.append(OpenRouterMessage(role: "system", content: characterScenario))
+        }
+
+        let chatMessages: [OpenRouterMessage] = messages.map { OpenRouterMessage(role: $0.role.rawValue, content: $0.message) }
+        let openRouterMessages = systemMessages + chatMessages
+
+        return OpenRouterPromptModel(
+            model: model,
+            messages: openRouterMessages,
+            stop: stop,
+            temperature: temperature,
+            topP: topP,
+            minP: minP,
+            topA: topA,
+            topK: topK,
+            maxTokens: maxTokens,
+            repetitionPenalty: repetitionPenalty,
+            stream: stream,
+            presencePenalty: presencePenalty,
+            frequencyPenalty: frequencyPenalty
+        )
+    }
+}
+
+// MARK: - Kobold
+public struct KoboldRequestBuilder: EncodableRequestBuilder {
+    public typealias RequestModel = KoboldPromptModel
+
+    // Required
+    public var prompt: String
+
+    // Optional
+    public var memory: String?
+    public var maxContextLength: Int?
+    public var maxLength: Int?
+    public var temperature: Double?
+    public var tfs: Int?
+    public var topA: Double?
+    public var topK: Double?
+    public var topP: Double?
+    public var minP: Double?
+    public var typical: Int?
+    public var repetitionPenalty: Double?
+    public var repetitionRange: Int?
+    public var repetitionSlope: Double?
+    public var stopSequence: [String]?
+    public var trimStop: Bool?
+    public var samplerOrder: [Int]?
+    public var promptTemplate: String?
+
+    public init(
+        prompt: String,
+        memory: String? = nil,
+        maxContextLength: Int? = 4096,
+        maxLength: Int? = 240,
+        temperature: Double? = 0.75,
+        tfs: Int? = 1,
+        topA: Double? = 0.92,
+        topK: Double? = 100,
+        topP: Double? = 0.92,
+        minP: Double? = 0,
+        typical: Int? = 1,
+        repetitionPenalty: Double? = 1.07,
+        repetitionRange: Int? = 360,
+        repetitionSlope: Double? = 0.7,
+        stopSequence: [String]? = ["\nUser:", "\nBot:"],
+        trimStop: Bool? = true,
+        samplerOrder: [Int]? = [6, 0, 1, 3, 4, 2, 5],
+        promptTemplate: String? = nil
+    ) {
+        self.prompt = prompt
+        self.memory = memory
+        self.maxContextLength = maxContextLength
+        self.maxLength = maxLength
+        self.temperature = temperature
+        self.tfs = tfs
+        self.topA = topA
+        self.topK = topK
+        self.topP = topP
+        self.minP = minP
+        self.typical = typical
+        self.repetitionPenalty = repetitionPenalty
+        self.repetitionRange = repetitionRange
+        self.repetitionSlope = repetitionSlope
+        self.stopSequence = stopSequence
+        self.trimStop = trimStop
+        self.samplerOrder = samplerOrder
+        self.promptTemplate = promptTemplate
+    }
+
+    public func build() -> KoboldPromptModel {
+        KoboldPromptModel(
+            maxContextLength: maxContextLength,
+            maxLength: maxLength,
+            prompt: prompt,
+            repPen: repetitionPenalty,
+            repPenRange: repetitionRange,
+            repPenSlope: repetitionSlope,
+            temperature: temperature,
+            tfs: tfs,
+            topA: topA,
+            topK: topK,
+            topP: topP,
+            minP: minP,
+            typical: typical,
+            memory: memory,
+            stopSequence: stopSequence,
+            trimStop: trimStop,
+            samplerOrder: samplerOrder,
+            promptTemplate: promptTemplate
+        )
+    }
+}
+
+


### PR DESCRIPTION
Adds Stream support for both OpenRouter and KoboldCPP. 

Moves to a cleaner builder based approach for sending responses. Old builder is still in place for compatibility but will be deprecated. 