### PR TITLE
Add model list for OpenAI

### DIFF
--- a/Sources/SwiftLLMSDK/APIManager.swift
+++ b/Sources/SwiftLLMSDK/APIManager.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/// manager class to handle API calls to different services. 
+/// manager class to handle API calls to different services.
 /// Kobold has to be "unique" and have a completely different API so we cant return OpenAI compliant responses....
 public class APIManager<T: LanguageModelService> {
     private let api: T
@@ -61,7 +61,17 @@ extension APIManager where T: OpenAPIBase {
             return .failure(.invalidService)
         }
 
-        return .success(api.selectedModel)
+        do {
+            let models = try await api.getModels().get()
+            if let selectedModel = api.selectedModel, let model = models.first(where: { $0.id == selectedModel })
+            {
+                return .success(model.id)
+            } else {
+                return .failure(.invalidService)
+            }
+        } catch (let error) {
+            return .failure(error)
+        }
     }
 
     public func sendMessage(builder: ChatCompletionRequestBuilder) async -> Result<ModelResponse, APIError> {
@@ -81,6 +91,14 @@ extension APIManager where T: OpenAPIBase {
         }
 
         return api.streamMessage(builder: builder)
+    }
+
+    public func getAvailableModels() async -> Result<[OpenAIModel], APIError> {
+        guard let api = api as? OpenAPI else {
+            return .failure(.invalidService)
+        }
+
+        return await api.getModels()
     }
 }
 
@@ -120,7 +138,8 @@ extension APIManager where T: KoboldAPIBase {
         return api.streamMessage(builder: builder)
     }
 
-    public func sendMessage(builder: KoboldRequestBuilder) async -> Result<ModelResponse, APIError> {
+    public func sendMessage(builder: KoboldRequestBuilder) async -> Result<ModelResponse, APIError>
+    {
         guard let api = api as? KoboldAPI else {
             return .failure(.invalidService)
         }
@@ -144,7 +163,7 @@ public struct ModelResponse: ResponseModel, @unchecked Sendable {
     public var streaming: Bool?
     public var disconnect: Bool = false
     public var rawResponse: Codable?
-    
+
     public init<T: Codable>(
         role: String? = "assistant",
         text: String? = nil,
@@ -165,7 +184,7 @@ public struct ModelResponse: ResponseModel, @unchecked Sendable {
         self.rawResponse = rawResponse
     }
 
-    // Init for non generic responses.. pretty much errors 
+    // Init for non generic responses.. pretty much errors
     public init(
         role: String? = "assistant",
         text: String? = nil,
@@ -184,7 +203,7 @@ public struct ModelResponse: ResponseModel, @unchecked Sendable {
         self.disconnect = disconnect
         self.rawResponse = nil
     }
-    
+
     /// Attempts to cast the rawResponse back to its original type
     /// - Returns: The original response type if casting succeeds, nil otherwise
     public func getRawResponse<T: Codable>() -> T? {

--- a/Sources/SwiftLLMSDK/OpenAPI/OpenAIListModel.swift
+++ b/Sources/SwiftLLMSDK/OpenAPI/OpenAIListModel.swift
@@ -1,0 +1,25 @@
+import Foundation 
+
+protocol APIModel {
+    var id: String { get }
+}
+
+public class OpenAIModelList: Codable {
+    public let data: [OpenAIModel]
+
+    public init (data: [OpenAIModel]) {
+        self.data = data
+    }
+}
+
+public class OpenAIModel: APIModel, Codable {
+    public let id: String
+    public let object: String? 
+    public let ownedBy: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case object
+        case ownedBy = "owned_by"
+    }
+}

--- a/Sources/SwiftLLMSDK/OpenAPI/OpenAPI.swift
+++ b/Sources/SwiftLLMSDK/OpenAPI/OpenAPI.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 public protocol OpenAPIBase {
-    var selectedModel: String { get }
+    var selectedModel: String? { get }
+    func getModels() async -> Result<[OpenAIModel], APIError>
 }
 
 public struct OpenAPI: LanguageModelService, OpenAPIBase {
@@ -10,7 +11,7 @@ public struct OpenAPI: LanguageModelService, OpenAPIBase {
     public var baseURL: String
     public var timeoutInterval: TimeInterval
 
-    public var selectedModel: String
+    public var selectedModel: String?
     public var apiKey: String?
 
     public init(
@@ -57,5 +58,20 @@ public struct OpenAPI: LanguageModelService, OpenAPIBase {
             method: "POST",
             requestBody: request.toJSON().data(using: .utf8)
         )
+    }
+
+    public func getModels() async -> Result<[OpenAIModel], APIError> {
+        let models = await sendRequest(
+            for: OpenAIModelList.self, 
+            path: "/models", 
+            method: "GET"
+        )
+
+        switch models {
+        case .success(let modelList): 
+            return .success(modelList.data)
+        case .failure(let error): 
+            return .failure(error)
+        }
     }
 }

--- a/Sources/SwiftLLMSDK/OpenRouter/OpenRouterListModel.swift
+++ b/Sources/SwiftLLMSDK/OpenRouter/OpenRouterListModel.swift
@@ -8,7 +8,7 @@ public class OpenRouterModelList: Codable {
     }
 }
 
-public class OpenRouterModel: Codable {
+public class OpenRouterModel: APIModel, Codable {
     public let id: String
     public let huggingFaceId: String?
     public let name: String


### PR DESCRIPTION
Adds get model list for openAI compatible endpoints. 

Note that connection logic needs to be re-worked. This should be handled on the front end until then. 